### PR TITLE
Compare desktop numbers numerically when sorting

### DIFF
--- a/ewmctrl.el
+++ b/ewmctrl.el
@@ -1,8 +1,9 @@
 ;;; ewmctrl.el --- Use `wmctrl' to manage desktop windows via EWMH/NetWM.
 
-;; Copyright (C) 2015-2016  Alexis <flexibeast@gmail.com>
+;; Copyright (C) 2015-2017  Alexis <flexibeast@gmail.com>, Adam Plaice <plaice.adam@gmail.com>
 
 ;; Author: Alexis <flexibeast@gmail.com>
+;;      Adam Plaice <plaice.adam@gmail.com>
 ;; Maintainer: Alexis <flexibeast@gmail.com>
 ;; Created: 2015-01-08
 ;; URL: https://github.com/flexibeast/ewmctrl
@@ -417,14 +418,18 @@ by ID."
     (cond
      ((eq 'desktop-number ewmctrl-sort-field)
       (sort windows-list #'(lambda (e1 e2)
-                             (string<
-                              (cdr (assoc 'desktop-number e1))
-                              (cdr (assoc 'desktop-number e2))))))
+                             (<
+                              (string-to-number
+                               (cdr (assoc 'desktop-number e1)))
+                              (string-to-number
+                               (cdr (assoc 'desktop-number e2)))))))
      ((eq 'desktop-number-reversed ewmctrl-sort-field)
       (sort windows-list #'(lambda (e1 e2)
-                             (string<
-                              (cdr (assoc 'desktop-number e2))
-                              (cdr (assoc 'desktop-number e1))))))
+                             (<
+                              (string-to-number
+                               (cdr (assoc 'desktop-number e2)))
+                              (string-to-number
+                               (cdr (assoc 'desktop-number e1)))))))
      ((eq 'name ewmctrl-sort-field)
       (sort windows-list #'(lambda (e1 e2)
                              (string<


### PR DESCRIPTION
Otherwise, with large desktop numbers (≤10) the sort order will be
unexpected — for example, windows on desktop 11, will be placed between those on desktops 1 and 2.

Thank you for a very helpful elisp package!